### PR TITLE
Heat: simplify mpi/openmp detection using targets

### DIFF
--- a/interop/heat/CMakeLists.txt
+++ b/interop/heat/CMakeLists.txt
@@ -22,7 +22,7 @@ if (NOT MPI_FOUND)
 endif (NOT MPI_FOUND)
 
 set(CONT_SEARCH_DIRS)
-foreach(DIR ${MPI_INCLUDE_PATH})
+foreach(DIR ${MPI_CXX_INCLUDE_DIRS})
   list(APPEND CONT_SEARCH_DIRS "${DIR}/openmpi/mpiext")
 endforeach()
 
@@ -33,16 +33,7 @@ endif(NOT CONTINUATIONS_FOUND)
 
 if(ENABLE_OPENMP)
   set(BACKEND_NAME "OpenMP")
-
-  find_package(OpenMP ${OMP_MIN_VERSION})
-  if(OPENMP_FOUND)
-   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-  else()
-   message(SEND_ERROR "OPENMP SUPPORT NOT FOUND")
-  endif()
-
+  find_package(OpenMP ${OMP_MIN_VERSION} REQUIRED)
 endif()
 
 if(ENABLE_ARGOBOTS)
@@ -80,20 +71,25 @@ foreach(DIR ${SOURCE_DIRS})
   message(STATUS "DIR: ${DIR}")
   message(STATUS "TARGET_NAME: " ${TARGET_NAME})
 
-  add_executable(${TARGET_NAME} ${SUBDIR_SOURCES} ${SUBDIR_SOURCES})
+  add_executable(${TARGET_NAME} ${SUBDIR_SOURCES} ${SUBDIR_HEADERS})
   target_include_directories(${TARGET_NAME} PRIVATE ${DIR})
   target_include_directories(${TARGET_NAME} PRIVATE ${HEADER_DIRS})
   add_compile_options(-Wall -Wextra -pedantic -O3)
 
   if(ENABLE_ARGOBOTS)
      target_include_directories(${TARGET_NAME} PRIVATE ${ABT_INCLUDE_PATH})
-     target_link_libraries(${TARGET_NAME} ${ABT_LINK_LIBRARIES})
+     target_link_libraries(${TARGET_NAME} ${ABT_LINK_LIBRARIES} MPI::MPI_CXX)
   endif()
 
   if(ENABLE_QTHREADS)
     target_include_directories(${TARGET_NAME} PRIVATE ${QT_INCLUDE_PATH})
-    target_link_libraries(${TARGET_NAME} ${QT_LINK_LIBRARIES})    
+    target_link_libraries(${TARGET_NAME} ${QT_LINK_LIBRARIES} PUBLIC MPI::MPI_CXX)
   endif()
+
+  if(ENABLE_OPENMP)
+     target_link_libraries(${TARGET_NAME} PUBLIC OpenMP::OpenMP_CXX MPI::MPI_CXX)
+  endif()
+
 
   if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_compile_definitions(${TARGET_NAME} PUBLIC "DEBUG=1")

--- a/interop/heat/openmp/heat.cpp
+++ b/interop/heat/openmp/heat.cpp
@@ -59,7 +59,7 @@ inline void sendFirstComputeRow(block_t *matrix, int nbx, int nby, int rank, int
 			MPI_Isend(&matrix[nby+by][0], BSY, MPI_DOUBLE, rank - 1, by, MPI_COMM_WORLD, &request);
 			// TODO: Bind the completion of the task to the finalization of the MPI request (TAMPI_Iwait)
 			//TAMPI_Iwait(&request, MPI_STATUS_IGNORE);
-			MPIX_Continue(&request, &release_event, (void *) event, MPIX_CONT_PERSISTENT, MPI_STATUS_IGNORE, cont_req);
+			MPIX_Continue(&request, &release_event, (void *) event, MPIX_CONT_REQBUF_VOLATILE, MPI_STATUS_IGNORE, cont_req);
 		}
 	}
 }
@@ -74,7 +74,7 @@ inline void sendLastComputeRow(block_t *matrix, int nbx, int nby, int rank, int 
 			debug("Sending last compute row to %d tag %d\n", rank+1, by);
 			MPI_Isend(&matrix[(nbx-2)*nby + by][BSX-1], BSY, MPI_DOUBLE, rank + 1, by, MPI_COMM_WORLD, &request);
 			//TAMPI_Iwait(&request, MPI_STATUS_IGNORE);
-			MPIX_Continue(&request, &release_event, (void *) event, MPIX_CONT_PERSISTENT, MPI_STATUS_IGNORE, cont_req);
+			MPIX_Continue(&request, &release_event, (void *) event, MPIX_CONT_REQBUF_VOLATILE, MPI_STATUS_IGNORE, cont_req);
 		}
 	}
 
@@ -90,7 +90,7 @@ inline void receiveUpperBorder(block_t *matrix, int nbx, int nby, int rank, int 
 			debug("Receiving upper border from %d tag %d\n", rank-1, by);
 			MPI_Irecv(&matrix[by][BSX-1], BSY, MPI_DOUBLE, rank - 1, by, MPI_COMM_WORLD, &request);
 			//TAMPI_Iwait(&request, MPI_STATUS_IGNORE);
-			MPIX_Continue(&request, &release_event, (void *) event, MPIX_CONT_PERSISTENT, MPI_STATUS_IGNORE, cont_req);
+			MPIX_Continue(&request, &release_event, (void *) event, MPIX_CONT_REQBUF_VOLATILE, MPI_STATUS_IGNORE, cont_req);
 		}
 	}
 }
@@ -105,7 +105,7 @@ inline void receiveLowerBorder(block_t *matrix, int nbx, int nby, int rank, int 
 			debug("Receiving lower border from %d tag %d\n", rank+1, by);
 			MPI_Irecv(&matrix[(nbx-1)*nby + by][0], BSY, MPI_DOUBLE, rank + 1, by, MPI_COMM_WORLD, &request);
 			//TAMPI_Iwait(&request, MPI_STATUS_IGNORE);
-		    MPIX_Continue(&request, &release_event, (void *) event, MPIX_CONT_PERSISTENT, MPI_STATUS_IGNORE, cont_req);
+		    MPIX_Continue(&request, &release_event, (void *) event, MPIX_CONT_REQBUF_VOLATILE, MPI_STATUS_IGNORE, cont_req);
 		}
 	}
 }
@@ -149,7 +149,7 @@ double solve(block_t *matrix, int rowBlocks, int colBlocks, int timesteps) {
 	int rank, rank_size;
 	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 	MPI_Comm_size(MPI_COMM_WORLD, &rank_size);
-	MPIX_Continue_init(MPI_UNDEFINED, 0, MPI_INFO_NULL, &cont_req);
+	MPIX_Continue_init(0, 0, MPI_INFO_NULL, &cont_req);
 	MPI_Start(&cont_req);
 
     static volatile int do_progress = 1; // whether to keep triggering progress

--- a/interop/heat/openmp/heat.cpp
+++ b/interop/heat/openmp/heat.cpp
@@ -170,6 +170,10 @@ double solve(block_t *matrix, int rowBlocks, int colBlocks, int timesteps) {
           {
 		    int flag;
 	        MPI_Test(&cont_req, &flag, MPI_STATUS_IGNORE);
+            if (flag) {
+              // re-enable execution of continuations
+              MPI_Start(&cont_req);
+            }
             last_progress_ts = clock::now();
           }
           // it is not safe to yield before compute has started because the thread might steal the compute task

--- a/interop/heat/qthreads/heat.cpp
+++ b/interop/heat/qthreads/heat.cpp
@@ -206,6 +206,9 @@ aligned_t progress_task(void * args)
 	int flag = 0;
 	  while(do_progress) { 
 	        MPI_Test(&cont_req, &flag, MPI_STATUS_IGNORE);
+            if (flag) {
+              MPI_Start(&cont_req);
+            }
         	qthread_yield();        
       }
 	return 0;

--- a/interop/osu-micro-bench/argobots/osu_latency_abt_cont.c
+++ b/interop/osu-micro-bench/argobots/osu_latency_abt_cont.c
@@ -80,6 +80,7 @@ int main(int argc, char *argv[])
     err = MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
 
     MPIX_Continue_init(&cont_req, MPI_INFO_NULL);
+    MPI_Start(&cont_req);
 
     ABT_init(argc, argv);
     ABT_xstream_self(&es);
@@ -441,6 +442,9 @@ void cont_progress(void* data)
         //do {
         //completed = 0;
         MPI_Test(&cont_req, &flag, MPI_STATUS_IGNORE);
+        if (flag) {
+          MPI_Start(&cont_req);
+        }
         //} while (completed > 0);
         ABT_thread_yield();
     }

--- a/interop/osu-micro-bench/qthreads/osu_latency_qt_cont.c
+++ b/interop/osu-micro-bench/qthreads/osu_latency_qt_cont.c
@@ -96,6 +96,7 @@ int main(int argc, char *argv[])
     err = MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
 
     MPIX_Continue_init(&cont_req, MPI_INFO_NULL);
+    MPI_Start(&cont_req);
 
     //abt ABT_init(argc, argv);
     if(options.sender_sheps!=-1) {
@@ -550,6 +551,9 @@ aligned_t cont_progress(void* data)
         //do {
         //completed = 0;
         MPI_Test(&cont_req, &flag, MPI_STATUS_IGNORE);
+        if (flag) {
+          MPI_Start(&cont_req);
+        }
         //} while (completed > 0);
         //abt ABT_thread_yield();
         qthread_yield();


### PR DESCRIPTION
No need to pass MPI_INCLUDE_PATH and it's now possible to set an alternative backend compiler.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>